### PR TITLE
AttributeError while running tests

### DIFF
--- a/django_hstore/postgresql_psycopg2/base.py
+++ b/django_hstore/postgresql_psycopg2/base.py
@@ -56,7 +56,7 @@ class DatabaseCreation(DatabaseCreation):
         if cursor.fetchone():
             # skip if already exists
             return
-        if self.connection._version[0:2]>=(9,1):
+        if self.connection.pg_version >= 90100:
             cursor.execute("create extension hstore;")
             self.connection.commit_unless_managed()
             return


### PR DESCRIPTION
I had this error while launching tests for my django application::
  File "/home/fox/.virtualenvs/menubase/lib/python2.7/site-packages/django_hstore/postgresql_psycopg2/base.py", line 59, in install_hstore_contrib
    if self.connection._version[0:2]>=(9,1):
AttributeError: 'DatabaseWrapper' object has no attribute '_version'

Fixed modifying the check for the version
