### PR TITLE
Remove unicode argument to register_hstore function

### DIFF
--- a/django_hstore/postgresql_psycopg2/base.py
+++ b/django_hstore/postgresql_psycopg2/base.py
@@ -139,7 +139,8 @@ class DatabaseWrapper(DatabaseWrapper):
         cursor = super(DatabaseWrapper, self)._cursor()
 
         # register hstore extension
-        register_hstore(self.connection, globally=True, unicode=True)
+        #Gives error regarding unicode arg, so remove for now. Investigate later.
+        register_hstore(self.connection, globally=True)
 
         # bypass future registrations
         self._cursor = super(DatabaseWrapper, self)._cursor


### PR DESCRIPTION
Seems like the register_hstore function does not expect a unicode argument. So removed it. You can merge this if you want. Thanks for the library by the way. I am already using it and plan to use it more often in the future.
