### PR TITLE
Support for gt, gte, lt, lte and improve `contains` filter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ First, update your settings module to specify the custom database backend::
             ...
         }
     }
-    
+
 **Note to South users:** If you keep getting errors like `There is no South
 database module 'south.db.None' for your database.`, add the following to
 `settings.py`::
@@ -85,8 +85,17 @@ You can issue indexed queries against hstore fields::
     # equivalence
     Something.objects.filter(data={'a': '1', 'b': '2'})
 
+    # comparision
+    Something.objects.filter(data__gt={'a': '1'})
+    Something.objects.filter(data__gte={'a': '1'})
+    Something.objects.filter(data__lt={'a': '2'})
+    Something.objects.filter(data__lte={'a': '2'})
+
     # subset by key/value mapping
     Something.objects.filter(data__contains={'a': '1'})
+
+    # subset by list of some key values
+    Something.objects.filter(data__contains={'a': ['1', '2']})
 
     # subset by list of keys
     Something.objects.filter(data__contains=['a', 'b'])

--- a/django_hstore/query.py
+++ b/django_hstore/query.py
@@ -59,6 +59,13 @@ class HStoreWhereNode(WhereNode):
                     return ('%s = %%s' % field, [param])
                 else:
                     raise ValueError('invalid value')
+            elif lookup_type in ('gt', 'gte', 'lt', 'lte'):
+                if isinstance(param, dict) and len(param) == 1:
+                    sign = (lookup_type[0] == 'g' and '>%s' or '<%s') % (
+                        lookup_type[-1] == 'e' and '=' or '')
+                    return ('%s->\'%s\' %s %%s' % (field, param.keys()[0], sign), param.values())
+                else:
+                    raise ValueError('invalid value')
             elif lookup_type == 'contains':
                 if isinstance(param, dict):
                     return ('%s @> %%s' % field, [param])

--- a/django_hstore/query.py
+++ b/django_hstore/query.py
@@ -68,7 +68,11 @@ class HStoreWhereNode(WhereNode):
                     raise ValueError('invalid value')
             elif lookup_type == 'contains':
                 if isinstance(param, dict):
-                    return ('%s @> %%s' % field, [param])
+                    values = param.values()
+                    if len(values) == 1 and isinstance(values[0], (list, tuple)):
+                        return ('%s->\'%s\' = ANY(%%s)' % (field, param.keys()[0]), [map(str, values[0])])
+                    else:
+                        return ('%s @> %%s' % field, [param])
                 elif isinstance(param, (list, tuple)):
                     if param:
                         return ('%s ?& %%s' % field, [param])

--- a/tests/django_hstore_tests/tests.py
+++ b/tests/django_hstore_tests/tests.py
@@ -112,6 +112,24 @@ class TestDictionaryField(TestCase):
             self.assertEqual(len(r), 1)
             self.assertEqual(r[0], bag)
 
+    def test_key_value_gt_querying(self):
+        alpha, beta = self._create_bags()
+        self.assertGreater(beta.data['v'], alpha.data['v'])
+        r = DataBag.objects.filter(data__gt={'v': alpha.data['v']})
+        self.assertEqual(len(r), 1)
+        self.assertEqual(r[0], beta)
+        r = DataBag.objects.filter(data__gte={'v': alpha.data['v']})
+        self.assertEqual(len(r), 2)
+
+    def test_key_value_lt_querying(self):
+        alpha, beta = self._create_bags()
+        self.assertLess(alpha.data['v'], beta.data['v'])
+        r = DataBag.objects.filter(data__lt={'v': beta.data['v']})
+        self.assertEqual(len(r), 1)
+        self.assertEqual(r[0], alpha)
+        r = DataBag.objects.filter(data__lte={'v': beta.data['v']})
+        self.assertEqual(len(r), 2)
+
     def test_multiple_key_subset_querying(self):
         alpha, beta = self._create_bags()
         for keys in (['v'], ['v', 'v2']):

--- a/tests/django_hstore_tests/tests.py
+++ b/tests/django_hstore_tests/tests.py
@@ -26,7 +26,7 @@ class TestDictionaryField(TestCase):
         self.assertEqual(bag.data, {})
 
     def test_empty_querying(self):
-        bag = DataBag.objects.create(name='bag')
+        DataBag.objects.create(name='bag')
         self.assertTrue(DataBag.objects.get(data={}))
         self.assertTrue(DataBag.objects.filter(data={}))
         self.assertTrue(DataBag.objects.filter(data__contains={}))
@@ -111,6 +111,20 @@ class TestDictionaryField(TestCase):
             r = DataBag.objects.filter(data__contains={'v': bag.data['v'], 'v2': bag.data['v2']})
             self.assertEqual(len(r), 1)
             self.assertEqual(r[0], bag)
+
+    def test_value_in_subset_querying(self):
+        alpha, beta = self._create_bags()
+        r = DataBag.objects.filter(data__contains={'v': [alpha.data['v']]})
+        self.assertEqual(len(r), 1)
+        self.assertEqual(r[0], alpha)
+        r = DataBag.objects.filter(data__contains={'v': [alpha.data['v'], beta.data['v']]})
+        self.assertEqual(len(r), 2)
+        self.assertEqual(set(r), set([alpha, beta]))
+
+        # int values are ok
+        r = DataBag.objects.filter(data__contains={'v': [int(alpha.data['v'])]})
+        self.assertEqual(len(r), 1)
+        self.assertEqual(r[0], alpha)
 
     def test_key_value_gt_querying(self):
         alpha, beta = self._create_bags()
@@ -208,7 +222,7 @@ class TestReferencesField(TestCase):
         self.assertEqual(bag.refs, {})
 
     def test_empty_querying(self):
-        bag = RefsBag.objects.create(name='bag')
+        RefsBag.objects.create(name='bag')
         self.assertTrue(RefsBag.objects.get(refs={}))
         self.assertTrue(RefsBag.objects.filter(refs={}))
         self.assertTrue(RefsBag.objects.filter(refs__contains={}))


### PR DESCRIPTION
You can filter by some hash_store value 

```
Something.objects.filter(data__gt={'a': '1'})
Something.objects.filter(data__gte={'a': '1'})
Something.objects.filter(data__lt={'a': '2'})
Something.objects.filter(data__lte={'a': '2'})
```

Also `contains` may filter by list of values

```
Something.objects.filter(data__contains={'a': ['1', '2']})
```
